### PR TITLE
Update the page social link to the public repo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,4 +59,4 @@ extra:
     tokenizer: '[\s\-\.]+'
   social:
     - type: github-alt
-      link: https://github.com//securekubernetes/securekubernetes
+      link: https://github.com/securekubernetes/securekubernetes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,4 +59,4 @@ extra:
     tokenizer: '[\s\-\.]+'
   social:
     - type: github-alt
-      link: https://github.com/tabbysable/kubeconctf19
+      link: https://github.com//securekubernetes/securekubernetes


### PR DESCRIPTION
Hi
The bottom right social link back to the Github repo was pointing to the private version of the repo.
pretty cosmetic, but a nice-to-have ;)
